### PR TITLE
feat: add aborted view for oneclick mall

### DIFF
--- a/src/main/java/cl/transbank/webpay/example/controller/oneclick/OneclickMallController.java
+++ b/src/main/java/cl/transbank/webpay/example/controller/oneclick/OneclickMallController.java
@@ -59,7 +59,14 @@ public class OneclickMallController extends BaseController {
     public ModelAndView finish(@RequestParam("TBK_TOKEN") String token) {
         Map<String, Object> details = new HashMap<>();
         try {
+
             final OneclickMallInscriptionFinishResponse response = inscription.finish(token);
+            String tbkUser= response.getTbkUser();
+            String cardNumber = response.getCardNumber();
+            if(tbkUser==null && cardNumber==null)
+            {
+                return new ModelAndView("oneclick_mall/aborted", "details", details);
+            }
             details.put("token", token);
             details.put("response", response);
             details.put("tbk_user", response.getTbkUser());

--- a/src/main/webapp/WEB-INF/jsp/oneclick_mall/aborted.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oneclick_mall/aborted.jsp
@@ -15,8 +15,8 @@
 
 <div class="row">
 	<div class="col">
-		<h2>AnulaciÃ³n de compra</h2>
-		<p>El pago de la compra ha sido anulado por el usuario. En esta etapa, despuÃ©s de abandonar el formulario de pago, no es necesario realizar la confirmaciÃ³n. AquÃ­ te proporcionamos informaciÃ³n esencial sobre el estado de la transacciÃ³n anulada:</p>
+		<h2>Anulación de compra</h2>
+		<p>El pago de la compra ha sido anulado por el usuario. En esta etapa, después de abandonar el formulario de pago, no es necesario realizar la confirmación. Aquí te proporcionamos información esencial sobre el estado de la transacción anulada:</p>
 	</div>
 </div>
 <jsp:include page="../template/footer.jsp" />

--- a/src/main/webapp/WEB-INF/jsp/oneclick_mall/aborted.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oneclick_mall/aborted.jsp
@@ -16,7 +16,7 @@
 <div class="row">
 	<div class="col">
 		<h2>Anulación de compra</h2>
-		<p>El pago de la compra ha sido anulado por el usuario. En esta etapa, después de abandonar el formulario de pago, no es necesario realizar la confirmación. Aquí te proporcionamos información esencial sobre el estado de la transacción anulada:</p>
+		<p>El pago de la compra ha sido anulado por el usuario. En esta etapa, después de abandonar el formulario de pago, no es necesario realizar la confirmación.</p>
 	</div>
 </div>
 <jsp:include page="../template/footer.jsp" />

--- a/src/main/webapp/WEB-INF/jsp/oneclick_mall/aborted.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oneclick_mall/aborted.jsp
@@ -15,8 +15,8 @@
 
 <div class="row">
 	<div class="col">
-		<h2>Anulación de inscripción</h2>
-		<p>La inscripción ha sido anulada por el usuario. En esta etapa, después de abandonar el formulario, no es necesario realizar la confirmación.</p>
+		<h2>Inscripción cancelada</h2>
+		<p>La inscripción ha sido cancelada por el usuario. En esta etapa, después de abandonar el formulario, no es necesario realizar la confirmación.</p>
 	</div>
 </div>
 <jsp:include page="../template/footer.jsp" />

--- a/src/main/webapp/WEB-INF/jsp/oneclick_mall/aborted.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oneclick_mall/aborted.jsp
@@ -1,0 +1,25 @@
+<head>
+    <meta charset="UTF-8">
+
+</head>
+<jsp:include page="../template/tpl-header.jsp" />
+
+<body class="container">
+    <jsp:include page="../template/navbar-oneclick.jsp" />
+
+<style>
+	.row {
+		padding-bottom: 20px;
+	}
+</style>
+
+<div class="row">
+	<div class="col">
+		<h2>Anulación de compra</h2>
+		<p>El pago de la compra ha sido anulado por el usuario. En esta etapa, después de abandonar el formulario de pago, no es necesario realizar la confirmación. Aquí te proporcionamos información esencial sobre el estado de la transacción anulada:</p>
+	</div>
+</div>
+<jsp:include page="../template/footer.jsp" />
+
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/jsp/oneclick_mall/aborted.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oneclick_mall/aborted.jsp
@@ -15,8 +15,8 @@
 
 <div class="row">
 	<div class="col">
-		<h2>Anulación de compra</h2>
-		<p>El pago de la compra ha sido anulado por el usuario. En esta etapa, después de abandonar el formulario de pago, no es necesario realizar la confirmación.</p>
+		<h2>Anulación de inscripción</h2>
+		<p>La inscripción ha sido anulada por el usuario. En esta etapa, después de abandonar el formulario, no es necesario realizar la confirmación.</p>
 	</div>
 </div>
 <jsp:include page="../template/footer.jsp" />


### PR DESCRIPTION
This versión includes the following changes:

- Add  aborted view to cancel purchase in oneclick mall.
- Add condition in OneClickMallController to redirect to the aborted view when the cancel purchase action is performed.


These changes were made because currently the example project in the oneclick mall section was redirecting to the finish.jsp view when a purchase cancellation was performed.

> Case without modifications
![Captura de Pantalla 2024-06-13 a la(s) 18 17 46](https://github.com/TransbankDevelopers/transbank-sdk-java-webpay-rest-example/assets/99495937/e656b5b0-6658-46dc-9b0b-7b6a2f882042)

> Case with modifications
![Captura de Pantalla 2024-06-14 a la(s) 12 11 22](https://github.com/TransbankDevelopers/transbank-sdk-java-webpay-rest-example/assets/99495937/9ac3e3c3-ec79-461c-8ebf-20d715649e81)
