### PR TITLE
feat: add aborted view for oneclick mall deferred

### DIFF
--- a/src/main/java/cl/transbank/webpay/example/controller/oneclick/OneclickMallDeferredController.java
+++ b/src/main/java/cl/transbank/webpay/example/controller/oneclick/OneclickMallDeferredController.java
@@ -85,6 +85,12 @@ public class OneclickMallDeferredController extends BaseController {
       final OneclickMallInscriptionFinishResponse response = inscription.finish(
         token
       );
+      String tbkUser= response.getTbkUser();
+      String cardNumber = response.getCardNumber();
+      if(tbkUser==null && cardNumber==null)
+      {
+        return new ModelAndView("oneclick_mall_deferred/aborted", "details", details);
+      }
       details.put("token", token);
       details.put("response", response);
       details.put("tbk_user", response.getTbkUser());

--- a/src/main/webapp/WEB-INF/jsp/oneclick_mall_deferred/aborted.jsp
+++ b/src/main/webapp/WEB-INF/jsp/oneclick_mall_deferred/aborted.jsp
@@ -1,0 +1,25 @@
+<head>
+    <meta charset="UTF-8">
+
+</head>
+<jsp:include page="../template/tpl-header.jsp" />
+
+<body class="container">
+    <jsp:include page="../template/navbar-oneclick.jsp" />
+
+<style>
+	.row {
+		padding-bottom: 20px;
+	}
+</style>
+
+<div class="row">
+	<div class="col">
+		<h2>Inscripción cancelada</h2>
+		<p>La inscripción ha sido cancelada por el usuario. En esta etapa, después de abandonar el formulario, no es necesario realizar la confirmación.</p>
+	</div>
+</div>
+<jsp:include page="../template/footer.jsp" />
+
+</body>
+</html>


### PR DESCRIPTION
This versión includes the following changes:

- Add aborted view to cancel purchase in oneclick mall deferred.
- Add condition in OneClickMallDeferredController to redirect to the aborted view when the cancel inscription action is performed.

These changes were made because currently the example project in the oneclick mall deferred section was redirecting to the finish.jsp view when an inscription cancellation was performed.

> Case without modifications
![Captura de Pantalla 2024-06-14 a la(s) 14 20 59](https://github.com/TransbankDevelopers/transbank-sdk-java-webpay-rest-example/assets/99495937/fdfeef6a-653d-4ffa-86ab-78a498359364)

> Case with modifications
![Captura de Pantalla 2024-06-14 a la(s) 14 22 47](https://github.com/TransbankDevelopers/transbank-sdk-java-webpay-rest-example/assets/99495937/77828bc8-ef21-447a-b553-eeff9af88078)


