### PR TITLE
feat: add aborted view for Webpay-plus-deferred

### DIFF
--- a/src/main/java/cl/transbank/webpay/example/controller/webpay/WebpayPlusDeferredController.java
+++ b/src/main/java/cl/transbank/webpay/example/controller/webpay/WebpayPlusDeferredController.java
@@ -72,7 +72,7 @@ public class WebpayPlusDeferredController extends BaseController {
             details.put("tbkToken", token);
             details.put("buyOrder", buyOrder);
             details.put("sessionId", sessionId);
-            return new ModelAndView("webpay_plus/aborted", "details", details);
+            return new ModelAndView("webpay_plus_deferred/aborted", "details", details);
         }
         log.info(String.format("token_ws : %s", tokenWs));
 

--- a/src/main/java/cl/transbank/webpay/example/controller/webpay/WebpayPlusDeferredController.java
+++ b/src/main/java/cl/transbank/webpay/example/controller/webpay/WebpayPlusDeferredController.java
@@ -46,7 +46,10 @@ public class WebpayPlusDeferredController extends BaseController {
             WebpayPlusTransactionCreateResponse response = tx.create(buyOrder, sessionId, amount, returnUrl);
             details.put("url", response.getUrl());
             details.put("token", response.getToken());
-
+            String token = response.getToken();
+            request.getSession().setAttribute("TBK_TOKEN", token);
+            request.getSession().setAttribute("buyOrder", buyOrder);
+            request.getSession().setAttribute("sessionId", sessionId);
             details.put("resp", toJson(response));
         }
         catch (Exception e) {
@@ -58,9 +61,21 @@ public class WebpayPlusDeferredController extends BaseController {
     }
 
     @RequestMapping(value = {"/webpay_plus_deferred/commit"}, method = { RequestMethod.GET, RequestMethod.POST })
-    public ModelAndView commit(@RequestParam("token_ws") String tokenWs, HttpServletRequest request) {
-        log.info(String.format("token_ws : %s", tokenWs));
+    public ModelAndView commit(HttpServletRequest request) {
+        String tokenWs = request.getParameter("token_ws");
         Map<String, Object> details = new HashMap<>();
+
+        if (tokenWs == null) {
+            String token = (String) request.getSession().getAttribute("TBK_TOKEN");
+            String buyOrder = (String) request.getSession().getAttribute("buyOrder");
+            String sessionId = (String) request.getSession().getAttribute("sessionId");
+            details.put("tbkToken", token);
+            details.put("buyOrder", buyOrder);
+            details.put("sessionId", sessionId);
+            return new ModelAndView("webpay_plus/aborted", "details", details);
+        }
+        log.info(String.format("token_ws : %s", tokenWs));
+
         try {
             final WebpayPlusTransactionCommitResponse response = tx.commit(tokenWs);
             log.debug(String.format("response : %s", response));

--- a/src/main/webapp/WEB-INF/jsp/webpay_plus_deferred/aborted.jsp
+++ b/src/main/webapp/WEB-INF/jsp/webpay_plus_deferred/aborted.jsp
@@ -16,17 +16,16 @@
 <div class="row">
 	<div class="col">
 		 <h2>Compra cancelada por el usuario</h2>
-         <p>Luego de que se anula la compra en el formulario de pago recibir√°s un GET con lo siguiente:</p>
+         <p>Luego de que se anula la compra en el formulario de pago recibir·s un GET con lo siguiente:</p>
 	</div>
 	<div class="row">
                 <div class="col m4">
                     <pre class="z-depth-2">
                           <code class="language-java">
                             {
-                                 'token_ws': '${details.token_ws}',
-                                 'tbk_token': '${details.tbkToken}',
-                                 'buyOrder': '${details.buyOrder}',
-                                 'sessionId': '${details.sessionId}',
+                                 'TBK_TOKEN': '${details.tbkToken}',
+                                 'TBK_ORDEN_COMPRA': '${details.buyOrder}',
+                                 'TBK_ID_SESION': '${details.sessionId}',
                             }
                         </code>
                     </pre>

--- a/src/main/webapp/WEB-INF/jsp/webpay_plus_deferred/aborted.jsp
+++ b/src/main/webapp/WEB-INF/jsp/webpay_plus_deferred/aborted.jsp
@@ -1,0 +1,39 @@
+<head>
+    <meta charset="UTF-8">
+
+</head>
+<jsp:include page="../template/tpl-header.jsp" />
+
+<body class="container">
+    <jsp:include page="../template/navbar-webpayplus.jsp" />
+
+<style>
+	.row {
+		padding-bottom: 20px;
+	}
+</style>
+
+<div class="row">
+	<div class="col">
+		 <h2>Compra cancelada por el usuario</h2>
+         <p>Luego de que se anula la compra en el formulario de pago recibirás un GET con lo siguiente:</p>
+	</div>
+	<div class="row">
+                <div class="col m4">
+                    <pre class="z-depth-2">
+                          <code class="language-java">
+                            {
+                                 'token_ws': '${details.token_ws}',
+                                 'tbk_token': '${details.tbkToken}',
+                                 'buyOrder': '${details.buyOrder}',
+                                 'sessionId': '${details.sessionId}',
+                            }
+                        </code>
+                    </pre>
+                </div>
+            </div>
+</div>
+<jsp:include page="../template/footer.jsp" />
+
+</body>
+</html>


### PR DESCRIPTION
This versión includes the following changes:

- Add aborted view to cancel purchase in webpay-plus-deferred.

- Add condition in WebpayPlusDeferredController to redirect to the aborted view when the cancel purchase action is performed.

These changes were made because currently the example project in the Webpay-plus-deferred section was redirecting to the error.jsp view when a purchase cancellation was performed.

>Case without modifications
<img width="376" alt="Captura de Pantalla 2024-06-18 a la(s) 11 40 55" src="https://github.com/TransbankDevelopers/transbank-sdk-java-webpay-rest-example/assets/99495937/58339136-8b89-4de6-b5ec-6422e9f2ba6d">

>Case with modifications
<img width="1074" alt="Captura de Pantalla 2024-06-18 a la(s) 13 22 17" src="https://github.com/TransbankDevelopers/transbank-sdk-java-webpay-rest-example/assets/99495937/e99b76db-41b2-47c3-9021-892018e859eb">

